### PR TITLE
Fixed Credits and Versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: CI-Release
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   clang-format:

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # UTag
 
-[![CI-Release](https://github.com/RiiConnect24/UTag/actions/workflows/ci.yml/badge.svg)](https://github.com/RiiConnect24/UTag/actions/workflows/ci.yml)
+[![CI-Release](https://github.com/t0g3pii/UTag/actions/workflows/ci.yml/badge.svg)](https://github.com/t0g3pii/UTag/actions/workflows/ci.yml)
 
-A Wii U plugin which sends the titles you play to your [RiiTag](https://tag.rc24.xyz/)!
+A Wii U plugin which sends the titles you play to your [RiiTag](https://riitag.t0g3pii.de/)!
 
 **This will only work with [Aroma](https://aroma.foryour.cafe/)!**
 
 ## Usage
 
 1. Install [Aroma](https://aroma.foryour.cafe/)
-2. Download the [latest stable release](https://github.com/RiiConnect24/UTag/releases/latest)
+2. Download the [latest stable release](https://github.com/t0g3pii/UTag/releases/latest)
 3. Place the `utag.wps` inside `SD://wiiu/environments/aroma/plugins/`
 4. Create a text file in `SD://wiiu/utag.txt`
 5. Paste your RiiTag key inside (you can find it on the RiiTag website
-   under ["Account"](https://tag.rc24.xyz/account)). Do NOT use Windows Notepad!
+   under ["Account"](https://riitag.t0g3pii.de/account)). Do NOT use Windows Notepad!
 
 **NOTE:** All titles except applets (browser, etc.) and system titles are counted, but not all
 games have covers.
@@ -32,7 +32,7 @@ If the [LoggingModule](https://github.com/wiiu-env/LoggingModule) is not present
 
 ### Server
 
-You can pass the `SERVER` variable to `make` to change the server domain. This makes it possible to use [your own RiiTag instance](https://github.com/WiiDatabase/RiiTag-Next). It defaults to `tag.rc24.xyz` (http).
+You can pass the `SERVER` variable to `make` to change the server domain. This makes it possible to use [your own RiiTag instance](https://github.com/WiiDatabase/RiiTag-Next). It defaults to `riitag.t0g3pii.de` (http).
 
 `make` Use `tag.rc24.xyz`
 `make SERVER=example.com` Use `example.com` as server

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 
 
 #ifndef SERVER
-#define SERVER "tag.rc24.xyz"
+#define SERVER "riitag.t0g3pii.de"
 #endif
 
 WUPS_PLUGIN_NAME("UTag");
@@ -75,7 +75,7 @@ ON_APPLICATION_REQUESTS_EXIT() {
         return;
     }
 
-    char tagURL[180];
+    char tagURL[256];
     char TID[17];
 
     uint32_t title_type     = title_id >> 32;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
 WUPS_PLUGIN_NAME("UTag");
 WUPS_PLUGIN_DESCRIPTION("Display the last played titles on your RiiTag.");
 WUPS_PLUGIN_VERSION(VERSION_FULL);
-WUPS_PLUGIN_AUTHOR("RiiConnect24, WiiDatabase.de");
+WUPS_PLUGIN_AUTHOR("t0g3pii, WiiLink former RiiConnect24, WiiDatabase.de");
 WUPS_PLUGIN_LICENSE("GPLv3");
 
 WUPS_USE_WUT_DEVOPTAB();

--- a/src/main.h
+++ b/src/main.h
@@ -2,5 +2,5 @@
 
 #include "version.h"
 
-#define VERSION      "v2.2.0"
+#define VERSION      "v2.2.2"
 #define VERSION_FULL VERSION VERSION_EXTRA


### PR DESCRIPTION
## Summary by Sourcery

Update RiiTag server and repository references, adjust plugin metadata, and revise CI trigger and version number.

Enhancements:
- Change default RiiTag server domain and documentation links to the new instance.
- Update plugin author credits and increase URL buffer size for tag requests.

CI:
- Modify CI workflow to run only on manual workflow_dispatch instead of pushes to master.

Documentation:
- Refresh README links for badges, releases, and account pages to point to the new GitHub repo and RiiTag domain.

Chores:
- Bump plugin version from v2.2.0 to v2.2.2.